### PR TITLE
revised query to see a list of tables that autovacuum sees as eligibl…

### DIFF
--- a/doc_source/Appendix.PostgreSQL.CommonDBATasks.md
+++ b/doc_source/Appendix.PostgreSQL.CommonDBATasks.md
@@ -394,7 +394,7 @@ autovacuum_freeze_max_age::float)
     or
     coalesce(cvbt.value::float, autovacuum_vacuum_threshold::float) + 
 coalesce(cvsf.value::float,autovacuum_vacuum_scale_factor::float) * 
-pg_table_size(c.oid) <= n_dead_tup
+c.reltuples <= n_dead_tup
    -- or 1 = 1
 )
 ORDER BY age(relfrozenxid) DESC LIMIT 50;


### PR DESCRIPTION
…ble for vacuuming

*Issue #, if available:*

As RDS documentation and official PostgreSQL documentation say,
the autovacuum threshold is defined as
"Vacuum threshold = vacuum base threshold + vacuum scale factor * number of tuples".
However, the query calculates by using "pg_table_size(c.oid)". 

*Description of changes:*

Please just show changed file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
