### PR TITLE
Update to reflect SQL Server MultiAZ in GovCloud

### DIFF
--- a/doc_source/USER_SQLServerMultiAZ.md
+++ b/doc_source/USER_SQLServerMultiAZ.md
@@ -14,7 +14,6 @@ Amazon RDS supports Multi\-AZ with Mirroring for the following SQL Server versio
 Amazon RDS supports Multi\-AZ with Mirroring for SQL Server in all AWS Regions, with the following exceptions:
 + Not supported 
   + US West \(N\. California\)
-  + AWS GovCloud \(US\)
 + Supported in most cases 
   + Asia Pacific \(Sydney\) – Supported for [DB instances in VPCs](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html#USER_VPC.Non-VPC2VPC)\.
   + Asia Pacific \(Tokyo\) – Supported for [DB instances in VPCs](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html#USER_VPC.Non-VPC2VPC)\.


### PR DESCRIPTION
This PR removes the line which stated RDS MS SQL Server MultiAZ was not available in us-gov-west-1

RDS MS SQL Server MultiAZ is now supported in GovCloud per this press release: https://aws.amazon.com/about-aws/whats-new/2018/05/amazon-rds-for-sql-server-adds-high-availability-support-to-the-govcloud-region/

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
