### PR TITLE
update quote used in dead tuples example

### DIFF
--- a/doc_source/CHAP_BestPractices.md
+++ b/doc_source/CHAP_BestPractices.md
@@ -252,7 +252,7 @@ The autovacuum parameters determine when and how hard autovacuum works\. The` au
 ```
 PROMPT> select relname, n_dead_tup, last_vacuum, last_autovacuum from 
 pg_catalog.pg_stat_all_tables
-where n_dead_tup > 0 and relname =  ’table1' order by n_dead_tup desc;
+where n_dead_tup > 0 and relname =  'table1' order by n_dead_tup desc;
 ```
 
 The results of the query will resemble the following:


### PR DESCRIPTION
*Description of changes:*
Replaced the character to use proper quote character. helpful when copying example and doing copy/replace on table

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
