### PR TITLE
Fix pgBadger snippet for pgBadger version 10.x

### DIFF
--- a/doc_source/Appendix.PostgreSQL.CommonDBATasks.md
+++ b/doc_source/Appendix.PostgreSQL.CommonDBATasks.md
@@ -879,7 +879,7 @@ You can use a log analyzer such as [pgbadger](http://dalibo.github.io/pgbadger/)
 For example, the following command correctly formats an Amazon RDS PostgreSQL log file dated 2014\-02\-04 using *pgbadger*\.
 
 ```
-./pgbadger -p '%t:%r:%u@%d:[%p]:' postgresql.log.2014-02-04-00 
+./pgbadger -f stderr -p '%t:%r:%u@%d:[%p]:' postgresql.log.2014-02-04-00 
 ```
 
 ## Viewing the Contents of pg\_config<a name="Appendix.PostgreSQL.CommonDBATasks.Viewingpgconfig"></a>


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awsdocs/amazon-rds-user-guide/issues/37

*Description of changes:*

Without `-f`, the provided snippet does not work consistently for pgBadger version 10.x. Although the snippet works consistently for pgBadger 9.x, the `-f stderr` option is backwards compatible, so it continues to work for 9.x and allows 10.x to work consistently.