### PR TITLE
pg_repack: Add repack required permissions

### DIFF
--- a/doc_source/Appendix.PostgreSQL.CommonDBATasks.md
+++ b/doc_source/Appendix.PostgreSQL.CommonDBATasks.md
@@ -764,6 +764,13 @@ You can use the `pg_repack` extension to remove bloat from tables and indexes\. 
    CREATE EXTENSION pg_repack;           
    ```
 
+1. Run the following commands to grant write access to repack temporary log tables created by `pg_repack`\. 
+
+   ```
+   ALTER DEFAULT PRIVILEGES IN SCHEMA repack GRANT INSERT ON TABLES TO PUBLIC;
+   ALTER DEFAULT PRIVILEGES IN SCHEMA repack GRANT USAGE, SELECT ON SEQUENCES TO PUBLIC;
+   ```
+
 1. Use the pg\_repack client utility to connect to a database\. Use a database role that has *rds\_superuser* privileges to connect to the database\. In the following connection example, the *rds\_test* role has *rds\_superuser* privileges, and the database endpoint used is *rds\-test\-instance\.cw7jjfgdr4on8\.us\-west\-2\.rds\.amazonaws\.com*\.
 
    ```


### PR DESCRIPTION
*Issue #, if available:* There's no issue about it, but I experienced some permission issues using `pg_repack` on a RDS PostgreSQL instance. The user that i used is the master user (with `rds_superuser` role), as related in documentation.

*Description of changes:* Add the commands to add default privileges in the `repack` schema to allow write access to repack log tables created during an `pg_repack` execution, evicting the following error: 
```
ProgrammingError: permission denied for relation log_17604
CONTEXT: SQL statement "INSERT INTO repack.log_17604(pk, row)
...
```

More details about it here: https://engineering.ometria.com/2018/01/29/using-pg_repack-with-aws-postgres-rds/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
