### PR TITLE
Update docs to reflect default database name

### DIFF
--- a/doc_source/USER_ConnectToPostgreSQLInstance.md
+++ b/doc_source/USER_ConnectToPostgreSQLInstance.md
@@ -47,6 +47,8 @@ You can use a local instance of the psql command line utility to connect to a Po
 
 Use one of the following formats to connect to a PostgreSQL DB instance on Amazon RDS\. When you connect, you're prompted for a password\. For batch jobs or scripts, use the `--no-password` option\.
 
+If this is the first time you are connecting to this instance, your `dbname` will most likely be `postgres`.
+
 For Unix, use the following format\.
 
 ```
@@ -86,3 +88,5 @@ If you can't connect to the DB instance, the most common error is `Could not con
 + Check whether the DB instance was created using a security group that doesn't authorize connections from the device or Amazon EC2 instance where the application is running\. For the connection to work, the security group you assigned to the DB instance at its creation must allow access to the DB instance\. For example, if the DB instance was created in a VPC, it must have a VPC security group that authorizes connections\. Alternatively, if the DB instance was created outside of a VPC, it must have a database security group that authorizes those connections\.
 
 By far the most common connection problem is with the security group's access rules assigned to the DB instance\. If you used the default DB security group when you created the DB instance, the security group likely didn't have access rules that allow you to access the instance\. For more information about Amazon RDS security groups, see [Controlling Access with Security Groups](Overview.RDSSecurityGroups.md)\.
+
+If you have an error like `FATAL:  database "some-name" does not exist` when connecting, try using `dbname=postgres` as the database name.


### PR DESCRIPTION
*Description of changes:*

Folks may not remember how overwhelming it is to get started with AWS. In hindsight, after a couple of Google searches for the error you do eventually find a solution. 

When creating the RDS instance you are prompted for a database name. This name turns out to be the instance name, not the database name. When using the commands for `psql` you will get an error along the lines of "the database name does not exist", which is in fact, true.

A database is created by default when there is no additional configuration and its name is `postgres`. I had this issue and using `postgres` as `dbname` solved my problem.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
