### PR TITLE
Postgres 9.6.12 only allows to jump to 10.7.

### DIFF
--- a/doc_source/USER_UpgradeDBInstance.PostgreSQL.md
+++ b/doc_source/USER_UpgradeDBInstance.PostgreSQL.md
@@ -64,7 +64,7 @@ You can upgrade a PostgreSQL database to its next major version\. From some Post
 | 9\.5\.16 | 9\.6\.x | [10\.7](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.version107), [11\.2](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.version112) | 
 | 9\.6\.x | 10\.x |  | 
 | 9\.6\.11 | 10\.x | [11\.1 ](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.version111) | 
-| 9\.6\.12 | 10\.x | [11\.2](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.version112) | 
+| 9\.6\.12 | 10\.7 | [11\.2](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.version112) | 
 | 10\.x | 11\.x |  | 
 
 **Important**  


### PR DESCRIPTION
*Issue https://github.com/awsdocs/amazon-rds-user-guide/issues/64*

*Description of changes:*
We have tested with CLI and console, Postgres 9.6.12 only allows to go to 10.7. 9.6.11 allows you to go to 10.6.
