### PR TITLE
Update VPC docs - minimize security group rules

### DIFF
--- a/doc_source/USER_VPC.Scenarios.md
+++ b/doc_source/USER_VPC.Scenarios.md
@@ -27,19 +27,22 @@ For a tutorial that shows you how to create a VPC with both public and private s
 
 1.  In the navigation pane, choose **Security Groups**\. 
 
-1. Select or create a security group for which you want to allow access to members of another security group\. In the scenario above, this would be the security group you will use for your DB instances\. Choose the **Inbound Rules** tab, and then choose **Edit rule**\.
+1. Select or create a security group to associate with your DB instances, to which you will allow access from members of another security group\. Choose the **Inbound Rules** tab, and then choose **Edit rules**\.
 
 1. On the **Edit inbound rules** page, choose **Add Rule**\.
 
-1. From **Type**, choose one of the **All ICMP** options\. In the **Source** box, start typing the ID of the security group; this provides you with a list of security groups\. Select the security group with members that you want to have access to the resources protected by this security group\. In the scenario above, this would be the security group you will use for your EC2 instance\.
+1. For **Type**, select the entry corresponding to the port you used when you created your DB instance, such as **MYSQL/Aurora**. If you configured your DB instance to use a non-default port, select **Custom TCP Rule** and enter the port manually\.
 
-1. Repeat the steps for the TCP protocol by creating a rule with **All TCP** as the **Type** and your security group in the **Source** box\. If you intend to use the UDP protocol, create a rule with **All UDP** as the **Type** and your security group in the **Source** box\. 
+1. In the **Source** box, enter the ID of the security group that you would like to grant access to the DB instance\. In the scenario above, this would be the security group you will use for your EC2 instance\.
 
-1. Create a custom TCP rule that permits access via the port you used when you created your DB instance, such as port 3306 for MySQL\. Enter your security group or an IP address you will use in the **Source** box\.
+1. Repeat the previous steps for any additional security groups that need to be granted access to the DB instance\.
 
 1. Choose **Save** when you are done\.
 
 ![\[adding a security group to another security group's rules\]](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/images/con-vpc-add-sg-rule.png)
+
+**Note**  
+ Some database types such as MS SQL may have additional protocol/port requirements to enable all of their features. Consult the documentation and repeat the above steps for any additional rules required\.
 
 ## A DB Instance in a VPC Accessed by an EC2 Instance in a Different VPC<a name="USER_VPC.Scenario3"></a>
 


### PR DESCRIPTION
*Description of changes:*

This section of the documentation seemed to advise opening up more network ports than needed, at least for MySQL and PostgreSQL databases.

After writing up the change, I remembered that MS SQL may (always?) need additional ports open, so I guess that might be why the example described opening all protocols+ports. I added a note at the bottom of the section to point this out and figured I'd send the PR anyway for the sake of discussion. But I appreciate it might be easier to leave things as-is to cover MS SQL.

I also realize that the screenshot for this section would no longer be completely accurate with my proposed changes, so there might need to be a corresponding edit to that (not sure if that can be done though GH?).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.