### PR TITLE
Fix typo in CHAP_PostgreSQL.md

### DIFF
--- a/doc_source/CHAP_PostgreSQL.md
+++ b/doc_source/CHAP_PostgreSQL.md
@@ -92,7 +92,7 @@ The PostgreSQL extensions supported in the Database Preview Environment are list
 |  hstore  |  1\.5  | 
 |  hstore\_plper  |  1\.0  | 
 |  intagg  |  1\.1  | 
-|  antarray  |  1\.2  | 
+|  intarray  |  1\.2  | 
 |  isn  |  1\.2  | 
 |  log\_fdw  |  1\.0  | 
 |  ltree  |  1\.1  | 


### PR DESCRIPTION
Typo in postgres array extension name: `s/antarray/intarray/`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
