### PR TITLE
replaced split -p with native Linux command

### DIFF
--- a/doc_source/UsingWithRDS.SSL-certificate-rotation.md
+++ b/doc_source/UsingWithRDS.SSL-certificate-rotation.md
@@ -171,7 +171,7 @@ truststore=${mydir}/rds-truststore.jks
 storepassword=changeit
 
 curl -sS "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem" > ${mydir}/rds-combined-ca-bundle.pem
-split -p "-----BEGIN CERTIFICATE-----" ${mydir}/rds-combined-ca-bundle.pem rds-ca-
+awk 'split_after == 1 {n++;split_after=0} /-----END CERTIFICATE-----/ {split_after=1}{print > "rds-ca-" n ".pem"}' < ${mydir}/rds-combined-ca-bundle.pem
 
 for CERT in rds-ca-*; do
   alias=$(openssl x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*CN=//; print')


### PR DESCRIPTION
split -p is only available on BSD based operating systems. 

The docs are stating that this should be ran on a Linux Operating System. 

When running split -p to split the chain into separate certificates, it fails with: 

: split: invalid option -- 'p' 
Try 'split --help' for more information.

*Issue #, if available:*

*Description of changes:*

Changed split -p for a Linux compatible option, to split the chain into separate certificates.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
