### PR TITLE
minor fix to create a ${mydir} in MacOS

### DIFF
--- a/doc_source/UsingWithRDS.SSL-certificate-rotation.md
+++ b/doc_source/UsingWithRDS.SSL-certificate-rotation.md
@@ -306,6 +306,7 @@ The following is a sample shell script that imports the certificate bundle into 
 mydir=/tmp/certs
 truststore=${mydir}/rds-truststore.jks
 storepassword=changeit
+mkdir ${mydir}
 
 curl -sS "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem" > ${mydir}/rds-combined-ca-bundle.pem
 split -p "-----BEGIN CERTIFICATE-----" ${mydir}/rds-combined-ca-bundle.pem rds-ca-


### PR DESCRIPTION
by default it would not create dir when download files and it would fail. Added mkdir for ${mydir} and it works out of gate

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
