### PR TITLE
syntax error in SELECT MASTER_POS_WAIT

### DIFF
--- a/doc_source/mysql-replication-gtid.md
+++ b/doc_source/mysql-replication-gtid.md
@@ -122,7 +122,7 @@ For an existing RDS MySQL DB instance with read replicas that doesn't use GTID\-
       For example, if the file name is `mysql-bin-changelog.000031` and the position is `107`, run the following statement\.
 
       ```
-      SELECT MASTER_POS_WAIT(mysql-bin-changelog.000031, 107);
+      SELECT MASTER_POS_WAIT('mysql-bin-changelog.000031', 107);
       ```
 
       If the read replica is past the specified position, the query returns immediately\. Otherwise, the function waits\. Proceed to the next step when the query returns for all read replicas\.
@@ -193,7 +193,7 @@ You can disable GTID\-based replication for an RDS MySQL DB instance with read r
       For example, if the file name is `mysql-bin-changelog.000031` and the position is `107`, run the following statement\.
 
       ```
-      SELECT MASTER_POS_WAIT(mysql-bin-changelog.000031, 107);
+      SELECT MASTER_POS_WAIT('mysql-bin-changelog.000031', 107);
       ```
 
       If the read replica is past the specified position, the query returns immediately\. Otherwise, the function waits\. When the query returns for all read replicas, go to the next step\. 


### PR DESCRIPTION
SELECT MASTER_POS_WAIT(mysql-bin-changelog.000031, 107); the statement should actually be 
SELECT MASTER_POS_WAIT('mysql-bin-changelog.000031', 107); 
I am working on MySQL 8.0 and for that if we don't use quotes it shows an error. Please make the necessary changes so other people can avoid this error.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
