### PR TITLE
[pg] Add limitation on password auth if IAM auth enabled 

### DIFF
--- a/doc_source/UsingWithRDS.IAMDBAuth.md
+++ b/doc_source/UsingWithRDS.IAMDBAuth.md
@@ -42,5 +42,6 @@ We recommend the following when using the MySQL engine:
 
 ## PostgreSQL Limitations for IAM Database Authentication<a name="UsingWithRDS.IAMDBAuth.LimitsPostgreSQL"></a>
 
-When using IAM database authentication with PostgreSQL, note the following limitation:
+When using IAM database authentication with PostgreSQL, note the following limitations:
 + The maximum number of connections per second for your database instance may be limited depending on the instance type and your workload\.
++ Users can only authenticate using either IAM Database Authentication or standard database authentication, but not both\.

--- a/doc_source/UsingWithRDS.IAMDBAuth.md
+++ b/doc_source/UsingWithRDS.IAMDBAuth.md
@@ -44,4 +44,4 @@ We recommend the following when using the MySQL engine:
 
 When using IAM database authentication with PostgreSQL, note the following limitations:
 + The maximum number of connections per second for your database instance may be limited depending on the instance type and your workload\.
-+ Users can only authenticate using either IAM Database Authentication or standard database authentication, but not both\.
++ Users can only be configured to authenticate using either IAM Database Authentication or standard database authentication, but not both\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I spent far too much time trying to figure out why standard password authentication wasn't working for a user only to realize it doesn't work when IAM database authentication is enabled, regardless of whether a password is set or not.

If a user is a member of the `rds_iam` role, then they can only log in using IAM database authentication.

If a user is _not_ a member of the `rds_iam` role, they can only log in using standard database authentication.

I've added this as a limitation under Postgres as I haven't tested the behavior on other database engines.

-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
