### PR TITLE
Page Improvement Suggestion: MySQL on Amazon RDS

### DIFF
--- a/doc_source/CHAP_MySQL.md
+++ b/doc_source/CHAP_MySQL.md
@@ -73,9 +73,9 @@ Replace *major\-engine\-version* with the major engine version, and replace *reg
 aws rds describe-db-engine-versions --default-only --engine mysql --engine-version 5.7 --region us-west-2 --query '*[].{Engine:Engine,EngineVersion:EngineVersion}' --output text
 ```
 
-With Amazon RDS, you control when to upgrade your MySQL instance to a new version supported by Amazon RDS\. You can maintain compatibility with specific MySQL versions, test new versions with your application before deploying in production, and perform version upgrades at times that best fit your schedule\.
+With Amazon RDS, you control when to upgrade your MySQL instance to a new major version supported by Amazon RDS \(i\.e\. going from version 5\.5 to 5\.6 or version 5\.7 to 8\.0\)\. You can maintain compatibility with specific MySQL versions, test new versions with your application before deploying in production, and perform major version upgrades at times that best fit your schedule\.
 
-Unless you specify otherwise, your DB instance will automatically be upgraded to new MySQL minor versions as they are supported by Amazon RDS\. This patching occurs during your scheduled maintenance window\. You can modify a DB instance to turn off automatic minor version upgrades\. 
+But unless you specify otherwise, your DB instance will automatically be upgraded to new MySQL minor versions as they are supported by Amazon RDS \(i\.e\. going from version 5\.5\.15 to 5\.5\.16\)\. This patching occurs during your scheduled maintenance window\. If you want, you can modify a DB instance to turn off automatic minor version upgrades\. 
 
 If you opt out of automatically scheduled upgrades, you can manually upgrade to a supported minor version release by following the same procedure as you would for a major version update\. For information, see [Upgrading a DB Instance Engine Version](USER_UpgradeDBInstance.Upgrading.md)\. 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Hello! I would like to suggest an improvement to the page "MySQL on Amazon RDS". When I was first reading this page, I found the section about automatic MySQL major and minor version upgrades a little bit confusing. At the top of the page, it was explained what "major version" and "minor version" means, but at a later paragraph, "version" and "major version" were used interchangeably which made it confusing for me as a first-time reader what was being said.

That's why I improved that paragraph to more precisely use "major version" in some places instead of "version", I believe this makes it more clear to the reader that Amazon RDS with MySQL will not automatically update major version, but it will automatically update minor version unless you specify otherwise.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.