### PR TITLE
Page Improvement Suggestion: Upgrading the PostgreSQL DB Engine for Amazon RDS

### DIFF
--- a/doc_source/USER_UpgradeDBInstance.PostgreSQL.md
+++ b/doc_source/USER_UpgradeDBInstance.PostgreSQL.md
@@ -6,7 +6,7 @@ When Amazon RDS supports a new version of a database engine, you can upgrade you
 
 In contrast, *minor version upgrades* include only changes that are backward\-compatible with existing applications\. You can initiate a minor version upgrade manually by modifying your DB instance\. Or you can enable the **Auto minor version upgrade** option when creating or modifying a DB instance\. Doing so means that your DB instance is automatically upgraded after Amazon RDS tests and approves the new version\. For more details, see [Automatic Minor Version Upgrades for PostgreSQL](#USER_UpgradeDBInstance.PostgreSQL.Minor)\. For information about manually performing a minor version upgrade, see [Manually Upgrading the Engine Version](USER_UpgradeDBInstance.Upgrading.md#USER_UpgradeDBInstance.Upgrading.Manual)\.
 
-If your PostgreSQL DB instance is using read replicas, you must upgrade all of the read replicas before upgrading the source instance\. If your DB instance is in a Multi\-AZ deployment, both the writer and standby replicas are upgraded\. Your DB instance might not be available until the upgrade is complete\. 
+If your PostgreSQL DB instance is using read replicas, you must first upgrade all of the read replicas before upgrading the source instance\. If your DB instance is in a Multi\-AZ deployment, then the writer and any standby replicas will be upgraded simultaneously\. That means your primary writer and also all standby replicas will be busy doing the upgrade process\. For this reason, your DB instance might not be available until the upgrade is complete\. 
 
 **Topics**
 + [Overview of Upgrading PostgreSQL](#USER_UpgradeDBInstance.PostgreSQL.Overview)
@@ -20,7 +20,7 @@ If your PostgreSQL DB instance is using read replicas, you must upgrade all of t
 
 To safely upgrade your DB instances, Amazon RDS uses the pg\_upgrade utility described in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/pgupgrade.html)\. 
 
-Amazon RDS takes two DB snapshots during the upgrade process if your backup retention period is greater than 0\. The first DB snapshot is of the DB instance before any upgrade changes have been made\. If the upgrade doesn't work for your databases, you can restore this snapshot to create a DB instance running the old version\. The second DB snapshot is taken after the upgrade completes\. 
+If your backup retention period is set to greater than 0, Amazon RDS will take two DB snapshots during the upgrade process\. The first DB snapshot is of the DB instance before any upgrade changes have been made\. If the upgrade doesn't work for your databases, you can restore this snapshot to create a DB instance running the old version\. The second DB snapshot is taken after the upgrade completes\. 
 
 **Note**  
 Amazon RDS takes DB snapshots during the upgrade process only if you have set the backup retention period for your DB instance to a number greater than 0\. To change your backup retention period, see [Modifying an Amazon RDS DB Instance](Overview.DBInstance.Modifying.md)\. 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Hello, I would like to suggest an improvement to the "Upgrading the PostgreSQL DB Engine for Amazon RDS" page. As a first time user of PostgreSQL with Amazon RDS, there were a few points that I believe could be clarified to help users like me.

The first change I am requesting is regarding how during an upgrade for a multi-AZ deployment, both the primary and standby replicas will be unavailable during the upgrade process. I believe my version makes it more clear to the reader why their database might not be available during an upgrade. The second change I am proposing is regarding the two DB snapshots that are made if the backup retention period is greater than 0, I believe reordering that line in the way that I am proposing makes it more clear.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.