### PR TITLE
Sample SQL correction.

### DIFF
--- a/doc_source/postgresql-s3-export.md
+++ b/doc_source/postgresql-s3-export.md
@@ -69,7 +69,7 @@ psql=> SELECT aws_commons.create_s3_uri(
    'sample-bucket',
    'sample-filepath',
    'us-west-2'
-) AS s3_uri_1 \gset
+) AS s3_uri_1; \gset
 ```
 
 You later provide this `s3_uri_1` value as a parameter in the call to the [aws\_s3\.query\_export\_to\_s3](#aws_s3.export_query_to_s3) function\. For examples, see [Exporting query data using the aws\_s3\.query\_export\_to\_s3 function](#postgresql-s3-export-examples)\.


### PR DESCRIPTION
Below fails.
```
psql=> SELECT aws_commons.create_s3_uri(
   'sample-bucket',
   'sample-filepath',
   'us-west-2'
) AS s3_uri_1 \gset
```
There should be a `;` before `\gset`.
Corrected one.
```
psql=> SELECT aws_commons.create_s3_uri(
   'sample-bucket',
   'sample-filepath',
   'us-west-2'
) AS s3_uri_1; \gset
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
