### PR TITLE
Update UsingWithRDS.IAMDBAuth.Connecting.Python.md: missing region in boto3.client call

### DIFF
--- a/doc_source/UsingWithRDS.IAMDBAuth.Connecting.Python.md
+++ b/doc_source/UsingWithRDS.IAMDBAuth.Connecting.Python.md
@@ -115,7 +115,7 @@ DBNAME="mydb"
 
 #gets the credentials from .aws/credentials
 session = boto3.Session(profile_name='RDSCreds')
-client = boto3.client('rds')
+client = boto3.client('rds', REGION)
 
 token = client.generate_db_auth_token(DBHostname=ENDPOINT, Port=PORT, DBUsername=USR, Region=REGION)
 


### PR DESCRIPTION
`boto3.client` call missing region. Calling code as written raises `NoRegionError`.

*Description of changes:*
Add region 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
