### PR TITLE
Remove `slave_lag` alias from PostgreSQL query

### DIFF
--- a/doc_source/USER_ReadRepl.md
+++ b/doc_source/USER_ReadRepl.md
@@ -264,7 +264,7 @@ New databases aren't included in the lag calculation until they are accessible o
 For PostgreSQL, the `ReplicaLag` metric returns the value of the following query\.
 
 ```
-SELECT extract(epoch from now() - pg_last_xact_replay_timestamp()) AS slave_lag
+SELECT extract(epoch from now() - pg_last_xact_replay_timestamp())
 ```
 
 PostgreSQL versions 9\.5\.2 and later use physical replication slots to manage write ahead log \(WAL\) retention on the source instance\. For each cross\-Region read replica instance, Amazon RDS creates a physical replication slot and associates it with the instance\. Two Amazon CloudWatch metrics, `Oldest Replication Slot Lag` and `Transaction Logs Disk Usage`, show how far behind the most lagging replica is in terms of WAL data received and how much storage is being used for WAL data\. The `Transaction Logs Disk Usage` value can substantially increase when a cross\-Region read replica is lagging significantly\.


### PR DESCRIPTION
**Description of changes**
- Removes the `AS slave_lag` alias in the PostgreSQL query that returns the value for the RDS `ReplicaLag` metric

**Reason for the change**
- Words like "slave" are insensitive and alienate people of color
  - For example, the [W3C style guide](https://w3c.github.io/manual-of-style/#inclusive) "strongly encourage[s]" members to avoid terms like "slave" for the purpose of promoting inclusion and facilitating diversity. There are [many other organizations](https://www.nytimes.com/2021/04/13/technology/racist-computer-engineering-terms-ietf.html) that have done this as well.
- The context makes it pretty obvious that the query returns a value representing replication lag, so an alias is unnecessary

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.