### PR TITLE
Normalize file names

### DIFF
--- a/doc_source/ssl-certificate-rotation-mysql.md
+++ b/doc_source/ssl-certificate-rotation-mysql.md
@@ -121,7 +121,7 @@ You can update the trust store for applications that use JDBC for SSL/TLS connec
 1. Import the certificate into the key store using the following command\. 
 
    ```
-   keytool -import -alias rds-root -keystore clientkeystore -file rds-ca-2019-root.der                    
+   keytool -import -alias rds-root -keystore clientkeystore.jks -file rds-ca-2019-root.der                    
    ```
 
 1. Confirm that the key store was updated successfully\.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

The "import the certificate" step was creating a keystore named `clientkeystore`, but then the following "confirm" step was trying to open a file named `clientkeystore.jks`. This caused a "Keystore file does not exist" error to be thrown, and correcting the commands to both reference the same file resolves the error.

Sorry for updating the last line of the file, that happened automatically since I'm just using the webapp.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
