### PR TITLE
fixing syntax error in multiple recipients Example

### DIFF
--- a/doc_source/SQLServer.DBMail.md
+++ b/doc_source/SQLServer.DBMail.md
@@ -370,7 +370,7 @@ GO
 
 EXEC msdb.dbo.sp_send_dbmail
      @profile_name       = 'Notifications',
-     @recipients         = 'recipient1@example.com;'recipient2@example.com',
+     @recipients         = 'recipient1@example.com;recipient2@example.com',
      @subject            = 'Automated DBMail message - 2',
      @body               = 'This is a message.';
 GO


### PR DESCRIPTION

*Issue #, if available:*
syntax error in sending e-mail to multiple recipients example.

*Description of changes:*
**removed** extra <b>`'`</b>

>From: 'recipient1@example.com;'recipient2@example.com',
To: 'recipient1@example.com;recipient2@example.com',



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
