### PR TITLE
Improve Readability of MySQL Error Logging

### DIFF
--- a/doc_source/USER_LogAccess.MySQL.Errorlog.md
+++ b/doc_source/USER_LogAccess.MySQL.Errorlog.md
@@ -1,12 +1,7 @@
 # Accessing MySQL error logs<a name="USER_LogAccess.MySQL.Errorlog"></a>
 
-MySQL writes errors in the `mysql-error.log` file\. Each log file has the hour it was generated \(in UTC\) appended to its name\. The log files also have a timestamp that helps you determine when the log entries were written\.
+MySQL writes to the error log (`mysql-error.log`) only on startup, shutdown, and when it encounters errors\. A DB instance can go hours or days without new entries being written to the error log\. If you see no recent entries, it's because the server did not encounter an error that would result in a log entry\.
 
-MySQL writes to the error log only on startup, shutdown, and when it encounters errors\. A DB instance can go hours or days without new entries being written to the error log\. If you see no recent entries, it's because the server did not encounter an error that would result in a log entry\.
+MySQL writes `mysql-error.log` to disk every 5 minutes\. RDS appends the contents of the log to `mysql-error-running.log`\. 
 
-MySQL writes `mysql-error.log` to disk every 5 minutes\. MySQL appends the contents of the log to `mysql-error-running.log`\. 
-
-MySQL rotates the `mysql-error-running.log` file every hour\. RDS for MySQL retains the logs generated during the last two weeks\.
-
-**Note**  
-The log retention period is different between Amazon RDS and Aurora\.
+RDS rotates the `mysql-error-running.log` file every hour\. Each log file has the hour it was generated \(in UTC\) appended to its name\. The log files also have a timestamp that helps you determine when the log entries were written\. The generated logs are kept for last two weeks (Aurora) or one day (RDS)\.


### PR DESCRIPTION
Readability and Structure of these paragraphs were not good.
I've also tried to distinguish between what is done by MySQL and what is done by RDS (non mysql default behavior).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
