### PR TITLE
Updated ARN in example IAM policy

### DIFF
--- a/doc_source/USER_PerfInsights.access-control.md
+++ b/doc_source/USER_PerfInsights.access-control.md
@@ -39,7 +39,7 @@ For users who don't have full access with the `AmazonRDSFullAccess` policy, you 
            {
                "Effect": "Allow",
                "Action": "pi:*",
-               "Resource": "arn:aws::pi:*:*:metrics/rds/*"
+               "Resource": "arn:aws:pi:::metrics/rds/*"
            }
        ]
    }


### PR DESCRIPTION
The example ARN was malformed and contained unnecessary wildcards

