### PR TITLE
Update USER_PerfInsights.access-control.md

### DIFF
--- a/doc_source/USER_PerfInsights.access-control.md
+++ b/doc_source/USER_PerfInsights.access-control.md
@@ -39,7 +39,7 @@ For users who don't have full access with the `AmazonRDSFullAccess` policy, you 
            {
                "Effect": "Allow",
                "Action": "pi:*",
-               "Resource": "arn:aws::pi:*:*:metrics/rds/*"
+               "Resource": "arn:aws:pi:*:*:metrics/rds/*"
            }
        ]
    }


### PR DESCRIPTION
There is a typo on the performance index policy. It is correct this way: `"arn:aws:pi:*:*:metrics/rds/*"`
wrong: `"arn:aws::pi:*:*:metrics/rds/*"`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
