### PR TITLE
fix: add space between 'see' and 'mysql' words

### DIFF
--- a/doc_source/CHAP_GettingStarted.CreatingConnecting.MySQL.md
+++ b/doc_source/CHAP_GettingStarted.CreatingConnecting.MySQL.md
@@ -85,7 +85,7 @@ After Amazon RDS provisions your DB instance, you can use any standard SQL clien
 
 1. Install a SQL client that you can use to connect to the DB instance\.
 
-   You can connect to a MySQL DB instance by using tools like the mysql command line utility\. For more information on using the MySQL client, see[mysql \- the MySQL command\-line client](https://dev.mysql.com/doc/refman/8.0/en/mysql.html) in the MySQL documentation\. One GUI\-based application that you can use to connect is MySQL Workbench\. For more information, see the [Download MySQL Workbench](http://dev.mysql.com/downloads/workbench/) page\.
+   You can connect to a MySQL DB instance by using tools like the mysql command line utility\. For more information on using the MySQL client, see [mysql \- the MySQL command\-line client](https://dev.mysql.com/doc/refman/8.0/en/mysql.html) in the MySQL documentation\. One GUI\-based application that you can use to connect is MySQL Workbench\. For more information, see the [Download MySQL Workbench](http://dev.mysql.com/downloads/workbench/) page\.
 
    For more information on using MySQL, see the [MySQL documentation](http://dev.mysql.com/doc/)\. For information about installing MySQL \(including the MySQL client\), see [Installing and upgrading MySQL](https://dev.mysql.com/doc/refman/8.0/en/installing.html)\.
 


### PR DESCRIPTION
Signed-off-by: Rommy Gustiawan <rgcppp@gmail.com>

*Issue #, if available:*
Simple typo error.

*Description of changes:*
This changes fixed the issue by adding a space between the word 'see' and 'mysql'.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
