### PR TITLE
Amend an RDS event id

### DIFF
--- a/doc_source/USER_Events.Messages.md
+++ b/doc_source/USER_Events.Messages.md
@@ -104,7 +104,7 @@ The following table shows the event category and a list of events when a DB inst
 |  recovery  | RDS\-EVENT\-0053 |  Recovery of the Multi\-AZ instance is complete\.  | 
 |  recovery  | RDS\-EVENT\-0066 |  The SQL Server DB instance is re\-establishing its mirror\. Performance will be degraded until the mirror is reestablished\. A database was found with non\-FULL recovery model\. The recovery model was changed back to FULL and mirroring recovery was started\. \(<dbname>: <recovery model found>\[,\.\.\.\]\)"  | 
 |  recovery  | RDS\-EVENT\-0166 |  The RDS Custom DB instance is inside the support perimeter\.  | 
-|  restoration  | RDS\-EVENT\-0008 |  The DB instance has been restored from a DB snapshot\.  | 
+|  restoration  | RDS\-EVENT\-0043 |  The DB instance has been restored from a DB snapshot\.  | 
 |  restoration  | RDS\-EVENT\-0019 |  The DB instance has been restored from a point\-in\-time backup\.  | 
 |  security  | RDS\-EVENT\-0068 |  RDS is decrypting the CloudHSM partition password to make updates to the instance\. For more information see [Oracle Database Transparent Data Encryption \(TDE\) with AWS CloudHSM](https://docs.aws.amazon.com/cloudhsm/latest/userguide/oracle-tde.html) in the *AWS CloudHSM User Guide*\.  | 
 


### PR DESCRIPTION
Fix RDS event id of DB instance being restored from snapshot

*Issue #, if available:* [Typo so no issue required](https://github.com/awsdocs/amazon-rds-user-guide/blob/main/CONTRIBUTING.md)

*Description of changes:* Use the correct Event Id for when a DB instance is restored from a snapshot


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
