### PR TITLE
Wrong SQL used

### DIFF
--- a/doc_source/Appendix.Oracle.Options.APEX.md
+++ b/doc_source/Appendix.Oracle.Options.APEX.md
@@ -104,7 +104,7 @@ You can do this by using the Oracle SQL\*Plus command line utility\. Connect to 
 
 ```
 1. ALTER USER APEX_PUBLIC_USER IDENTIFIED BY new_password;
-2. ALTER USER APEX_PUBLIC_USER ACCOUNT UNLOCKED;
+2. ALTER USER APEX_PUBLIC_USER ACCOUNT UNLOCK;
 ```
 
 ## Configuring RESTful services for Oracle APEX<a name="Appendix.Oracle.Options.APEX.ConfigureRESTful"></a>


### PR DESCRIPTION
SQL syntax is wrong. Will throw an error
```
SQL> ALTER USER APEX_PUBLIC_USER ACCOUNT UNLOCKED;
ALTER USER APEX_PUBLIC_USER ACCOUNT UNLOCKED
                                    *
ERROR at line 1:
ORA-00921: unexpected end of SQL command
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
