### PR TITLE
Add pg_repack upgrade notes

### DIFF
--- a/doc_source/USER_UpgradeDBInstance.PostgreSQL.md
+++ b/doc_source/USER_UpgradeDBInstance.PostgreSQL.md
@@ -391,6 +391,9 @@ A PostgreSQL engine upgrade doesn't upgrade most PostgreSQL extensions\. To upda
 **Note**  
 If you are running the `PostGIS` extension in your Amazon RDS PostgreSQL DB instance, make sure that you follow the [PostGIS upgrade instructions](https://postgis.net/docs/postgis_installation.html#upgrading) in the PostGIS documentation before you update the extension\. 
 
+**Note**  
+If you are running the `pg_repack` extension in your Amazon RDS PostgreSQL DB instance, make sure that you follow the [pg_repack install instructions](https://reorg.github.io/pg_repack/) in the documentation to update the extension\. 
+
 To upgrade an extension, use the following command\. 
 
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`pg_repack` does not have an extension update path. So to upgrade the extension, it should be dropped and created.

> If you are upgrading from a previous version of pg_repack or pg_reorg, just drop the old version from the database as explained above and install the new version.

I have spent a day trying to figure this information out. Because it was not mentioned in the AWS upgrade guide.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
