### PR TITLE
Fix create-role examples in aws_s3 extension docs

### DIFF
--- a/doc_source/postgresql-s3-export.md
+++ b/doc_source/postgresql-s3-export.md
@@ -176,7 +176,7 @@ We strongly recommend that you do not create a policy with all\-resource access\
             "Condition": {
                 "StringEquals": {
                    "aws:SourceAccount": 111122223333,
-                   "aws:SourceArn": arn:aws:rds:us-east-1:111122223333:db:dbname
+                   "aws:SourceArn": "arn:aws:rds:us-east-1:111122223333:db:dbname"
                    }
                 }
           }
@@ -201,7 +201,7 @@ We strongly recommend that you do not create a policy with all\-resource access\
             "Condition": {
                 "StringEquals": {
                    "aws:SourceAccount": 111122223333,
-                   "aws:SourceArn": arn:aws:rds:us-east-1:111122223333:db:dbname
+                   "aws:SourceArn": "arn:aws:rds:us-east-1:111122223333:db:dbname"
                    }
                 }
           }


### PR DESCRIPTION
*Issue #, if available:*
No issue, just typo in examples

*Description of changes:*
The `aws:SourceArn` field value has to be enclosed in quotes, otherwise the command will fail with "An error occurred (MalformedPolicyDocument) when calling the CreateRole operation: This policy contains invalid Json".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
