### PR TITLE
Remove inaccurate statement about burst relevance

### DIFF
--- a/doc_source/CHAP_Storage.md
+++ b/doc_source/CHAP_Storage.md
@@ -29,7 +29,6 @@ Volumes below 1 TiB in size also have ability to burst to 3,000 IOPS for extende
 
 Many workloads never deplete the burst balance, making General Purpose SSD an ideal storage choice for many workloads\. However, some workloads can exhaust the 3,000 IOPS burst storage credit balance, so you should plan your storage capacity to meet the needs of your workloads\.
 
-For gp2 volumes larger than 1 TiB, the baseline performance is greater than the burst performance\. For such volumes, burst is irrelevant because the baseline performance is better than the 3,000 IOPS burst performance\.
 
 **Note**  
 DB instances that use General Purpose SSD storage can experience much longer latency after read replica creation, Multi\-AZ conversion, and DB snapshot restoration than instances that use Provisioned IOPS storage\. If you need a DB instance with minimum latency after these operations, we recommend using Provisioned IOPS storage\.


### PR DESCRIPTION
This statement is at best misleading, at worst inaccurate, as the concept of burst I/O is very much still relevant for volumes larger than 1TiB.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
