### PR TITLE
Syntax error in the SMTP secret policy

### DIFF
--- a/doc_source/Appendix.SQLServer.Options.SSRS.md
+++ b/doc_source/Appendix.SQLServer.Options.SSRS.md
@@ -467,7 +467,7 @@ If you change the secret later, you also have to update the `SSRS` option in the
      "Statement" : [ {
        "Effect" : "Allow",
        "Principal" : {
-         "Service" : "rds.amazonaws.com",
+         "Service" : "rds.amazonaws.com"
        },
        "Action" : "secretsmanager:GetSecretValue",
        "Resource" : "*",


### PR DESCRIPTION
The policy for accessing the SMTP secret contains a syntax error that prevent it from being applied in AWS Secrets Manager, this pull request fixes that.

The change just removes the extra comma in the dictionary, which fixes the syntax error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
