### PR TITLE
t4g aren't described as powered by AWS Graviton2

### DIFF
--- a/doc_source/Concepts.DBInstanceClass.md
+++ b/doc_source/Concepts.DBInstanceClass.md
@@ -243,7 +243,7 @@ In the following table, you can find details about supported Amazon RDS DB insta
 | db\.r3\.2xlarge | Yes | Yes | Yes | Deprecated | Lower than PostgreSQL 13 | 
 | db\.r3\.xlarge | Yes | Yes | Yes | Deprecated | Lower than PostgreSQL 13 | 
 | db\.r3\.large | Yes | Yes | Yes | Deprecated | Lower than PostgreSQL 13 | 
-| db\.t4g – burstable\-performance instance classes | 
+| db\.t4g – burstable\-performance instance classes powered by AWS Graviton2 processors | 
 | db\.t4g\.2xlarge | All MariaDB 10\.6 versions, all MariaDB 10\.5 versions, and all MariaDB 10\.4 versions | No | MySQL 8\.0\.25 & higher | No | All PostgreSQL 14 versions, all PostgreSQL 13 versions, PostgreSQL 12\.7 and higher | 
 | db\.t4g\.xlarge | All MariaDB 10\.6 versions, all MariaDB 10\.5 versions, and all MariaDB 10\.4 versions | No | MySQL 8\.0\.25 & higher | No | All PostgreSQL 14 versions, all PostgreSQL 13 versions, PostgreSQL 12\.7 and higher | 
 | db\.t4g\.large | All MariaDB 10\.6 versions, all MariaDB 10\.5 versions, and all MariaDB 10\.4 versions | No | MySQL 8\.0\.25 & higher | No | All PostgreSQL 14 versions, all PostgreSQL 13 versions, PostgreSQL 12\.7 and higher | 


### PR DESCRIPTION
*Description of changes:*

Hi team,

This adds the mention `powered by AWS Graviton2 processors` to the `t4g` family.

Thanks,
Adrien

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
