### PR TITLE
fix(documentation): autovacuum value

### DIFF
--- a/doc_source/PostgreSQL.Procedural.Importing.md
+++ b/doc_source/PostgreSQL.Procedural.Importing.md
@@ -25,7 +25,7 @@ Modify your DB parameter group to include the following settings\. You should on
 |  `checkpoint_timeout`  |  1800  |  The value for this setting allows for less frequent WAL rotation\.  | 
 |  `synchronous_commit`  |  Off  |  Disable this setting to speed up writes\. Turning this parameter off can increase the risk of data loss in the event of a server crash \(do not turn off FSYNC\)\.  | 
 |  `wal_buffers`  |   8192  |  This is value is in 8 KB units\. This again helps your WAL generation speed  | 
-|  `autovacuum`  |  Off  |  Disable the PostgreSQL auto vacuum parameter while you are loading data so that it doesn't use resources  | 
+|  `autovacuum`  |  0  |  Disable the PostgreSQL auto vacuum parameter while you are loading data so that it doesn't use resources  | 
 
 Use the `pg_dump -Fc` \(compressed\) or `pg_restore -j` \(parallel\) commands with these settings\.
 


### PR DESCRIPTION
*Description of changes:*
This MR aims to change the value of `autovacuum` parameter. 
You can see on the following picture allowed values:
<img width="1631" alt="image" src="https://user-images.githubusercontent.com/20825264/204812718-316e9d7f-6646-4247-9ac2-4b161d9b6c5c.png">

This MR will also prevent the following continuous drift on Terraform stacks:

```terraform
# module.xxxx.rds.aws_db_parameter_group.postgres will be updated in-place
  ~ resource "aws_db_parameter_group" "postgres" {
        id          = "xxxxx"
        name        = "xxxxx"
      - parameter {
          - apply_method = "immediate" -> null
          - name         = "autovacuum" -> null
          - value        = "0" -> null
        }
      + parameter {
          + apply_method = "immediate"
          + name         = "autovacuum"
          + value        = "Off"
        }
    }
```
