### PR TITLE
Add remark for full backup compared to incremental

### DIFF
--- a/doc_source/USER_WorkingWithAutomatedBackups.md
+++ b/doc_source/USER_WorkingWithAutomatedBackups.md
@@ -8,10 +8,13 @@ Automated backups follow these rules:
 
 You can also back up your database manually by creating a DB snapshot\. For more information about manually creating a DB snapshot, see [Creating a DB snapshot](USER_CreateSnapshot.md)\. 
 
-The first snapshot of a database contains the data for the full database\. Subsequent snapshots of the same database are incremental\*, which means that only the data that has changed after your most recent snapshot is saved\.
+The first snapshot of a database contains the data for the full database\. Subsequent snapshots of the same database are incremental<sup>\*</sup>, which means that only the data that has changed after your most recent snapshot is saved\.
 
-**Note**
-\* Unless you perform failover to the standby instance which was never backed up before, then first snapshot will be full instead of incemental\. 
+---
+**NOTE** 
+<sup>\*</sup> Unless you perform failover to the standby instance which was never backed up before, then first snapshot will be full instead of incemental\. 
+
+---
 
 You can copy both automatic and manual DB snapshots, and share manual DB snapshots\. For more information about copying a DB snapshot, see [Copying a DB snapshot](USER_CopySnapshot.md)\. For more information about sharing a DB snapshot, see [Sharing a DB snapshot](USER_ShareSnapshot.md)\.
 

--- a/doc_source/USER_WorkingWithAutomatedBackups.md
+++ b/doc_source/USER_WorkingWithAutomatedBackups.md
@@ -8,7 +8,10 @@ Automated backups follow these rules:
 
 You can also back up your database manually by creating a DB snapshot\. For more information about manually creating a DB snapshot, see [Creating a DB snapshot](USER_CreateSnapshot.md)\. 
 
-The first snapshot of a database contains the data for the full database\. Subsequent snapshots of the same database are incremental, which means that only the data that has changed after your most recent snapshot is saved\.
+The first snapshot of a database contains the data for the full database\. Subsequent snapshots of the same database are incremental\*, which means that only the data that has changed after your most recent snapshot is saved\.
+
+**Note**
+\* Unless you perform failover to the standby instance which was never backed up before, then first snapshot will be full instead of incemental\. 
 
 You can copy both automatic and manual DB snapshots, and share manual DB snapshots\. For more information about copying a DB snapshot, see [Copying a DB snapshot](USER_CopySnapshot.md)\. For more information about sharing a DB snapshot, see [Sharing a DB snapshot](USER_ShareSnapshot.md)\.
 

--- a/doc_source/USER_WorkingWithAutomatedBackups.md
+++ b/doc_source/USER_WorkingWithAutomatedBackups.md
@@ -12,6 +12,7 @@ The first snapshot of a database contains the data for the full database\. Subse
 
 ---
 **NOTE** 
+
 <sup>\*</sup> Unless you perform failover to the standby instance which was never backed up before, then first snapshot will be full instead of incemental\. 
 
 ---

--- a/doc_source/USER_WorkingWithAutomatedBackups.md
+++ b/doc_source/USER_WorkingWithAutomatedBackups.md
@@ -13,7 +13,7 @@ The first snapshot of a database contains the data for the full database\. Subse
 ---
 **NOTE** 
 
-<sup>\*</sup> Unless you perform failover to the standby instance which was never backed up before, then first snapshot will be full instead of incemental\. 
+<sup>\*</sup> Unless you perform failover to the standby instance which was never backed up before, then first snapshot will be full instead of incremental\. 
 
 ---
 


### PR DESCRIPTION
*Issue #, if available: Misleading information about when we have full and incremental backup

*Description of changes:*
Add remark.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
